### PR TITLE
fix: unnecessary pop

### DIFF
--- a/lib/notification_banner.dart
+++ b/lib/notification_banner.dart
@@ -147,6 +147,7 @@ class NotificationBanner {
                           color: Colors.transparent,
                           child: GestureDetector(
                               onTap: () {
+                                hasBeenShown = true;
                                 if (_onTapped != null) {
                                   _onTapped();
                                 }


### PR DESCRIPTION
When tapping the banner, the hasBeenShown flag needed to be set to true.
Otherwise, an unnecessary `Navigator.pop(context);` will be executed at L:120.